### PR TITLE
Bump dependency on base

### DIFF
--- a/murmur-hash.cabal
+++ b/murmur-hash.cabal
@@ -21,7 +21,7 @@ Cabal-Version:   >= 1.6
 
 Library
   Build-Depends:
-    base          >= 3.0 && < 4.5,
+    base          >= 3.0 && < 4.6,
     bytestring    == 0.9.*
 
   exposed-modules:


### PR DESCRIPTION
This is required to build with GHC 7.4.
