### PR TITLE
Allow construction of hashes using their underlying representation

### DIFF
--- a/Data/Digest/Murmur32.hs
+++ b/Data/Digest/Murmur32.hs
@@ -13,7 +13,7 @@ MurmurHash2 algorithm.  See <http://murmurhash.googlepages.com> for
 details on MurmurHash2.
 -}
 module Data.Digest.Murmur32
-  ( Hash32, asWord32,
+  ( Hash32, asWord32, asHash32,
     Hashable32(..),
     hash32AddWord32, hash32AddInt, hash32, hash32WithSeed
   )
@@ -38,6 +38,10 @@ instance Show Hash32 where
 -- | Extract 32 bit word from hash.
 asWord32 :: Hash32 -> Word32
 asWord32 (Hash32 w) = w
+
+-- | Coerce a 32 bit word into a hash. This does not hash the input.
+asHash32 :: Word32 -> Hash32
+asHash32 = Hash32
 
 class Hashable32 a where
   hash32Add :: a -> Hash32 -> Hash32

--- a/Data/Digest/Murmur64.hs
+++ b/Data/Digest/Murmur64.hs
@@ -13,7 +13,7 @@ MurmurHash2 algorithm.  See <http://murmurhash.googlepages.com> for
 details on MurmurHash2.
 -}
 module Data.Digest.Murmur64
-  ( Hash64, asWord64,
+  ( Hash64, asWord64, asHash64,
     Hashable64(..),
     hash64AddWord64, hash64AddInt, hash64, hash64WithSeed, combine,
   )
@@ -38,6 +38,10 @@ instance Show Hash64 where
 -- | Extract 64 bit word from hash.
 asWord64 :: Hash64 -> Word64
 asWord64 (Hash64 w) = w
+
+-- | Coerce a 64 bit word into a hash. This does not hash the input.
+asHash64 :: Word64 -> Hash64
+asHash64 = Hash64
 
 class Hashable64 a where
   hash64Add :: a -> Hash64 -> Hash64

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+  - Introduce `asHash64` and `asHash32` which allow construction of `Hash64`
+    and `Hash32` respectively from their underlying word representation.
+
 ### 0.1.0.10
 
   - Replace use of deprecated `bitSize` by `finiteBitSize`


### PR DESCRIPTION
This opens the library up to operations on hashes that have not been constructed using this library. For example when passing through the FFI barrier or when deserializing hashes.

---

Regarding this approach, one could also expose the constructor of `Hash32` and `Hash64` instead. I wasn't sure which fits the API design philosophy of this package better. 