### PR TITLE
Fix spaceleak in `ByteString` hashing

### DIFF
--- a/Data/Digest/Murmur32.hs
+++ b/Data/Digest/Murmur32.hs
@@ -193,9 +193,9 @@ instance (Hashable32 a, Hashable32 b, Hashable32 c, Hashable32 d)
     hash32Add c `combine` hash32Add d
 
 instance Hashable32 B.ByteString where
-  hash32Add = B.foldl go (hash32AddWord32 8)
-    where go acc b = acc `combine` hash32AddWord32 (fromIntegral b)
+  hash32Add bs h = B.foldl' go (hash32AddWord32 8 h) bs
+    where go acc b = hash32AddWord32 (fromIntegral b) acc
 
 instance Hashable32 L.ByteString where
-  hash32Add = L.foldl go (hash32AddWord32 9)
-    where go acc b = acc `combine` hash32AddWord32 (fromIntegral b)
+  hash32Add bs h = L.foldl' go (hash32AddWord32 9 h) bs
+    where go acc b = hash32AddWord32 (fromIntegral b) acc

--- a/Data/Digest/Murmur64.hs
+++ b/Data/Digest/Murmur64.hs
@@ -189,9 +189,9 @@ instance (Hashable64 a, Hashable64 b, Hashable64 c, Hashable64 d)
     hash64Add c `combine` hash64Add d
 
 instance Hashable64 B.ByteString where
-  hash64Add = B.foldl go (hash64AddWord64 8)
-    where go acc b = acc `combine` hash64AddWord64 (fromIntegral b)
+  hash64Add bs h = B.foldl' go (hash64AddWord64 8 h) bs
+    where go acc b = hash64AddWord64 (fromIntegral b) acc
 
 instance Hashable64 L.ByteString where
-  hash64Add = L.foldl go (hash64AddWord64 9)
-    where go acc b = acc `combine` hash64AddWord64 (fromIntegral b)
+  hash64Add bs h = L.foldl' go (hash64AddWord64 9 h) bs
+    where go acc b = hash64AddWord64 (fromIntegral b) acc

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+### 0.1.0.11
+
+  - Fix space leak in `ByteString` instances
+    (PR [#15](https://github.com/nominolo/murmur-hash/pull/15)).
+    Fixes issue [#17](https://github.com/nominolo/murmur-hash/issues/17).
+
+  - Build tested with GHC 8.0 - 9.12.0.
+
+
 ### 0.1.0.10
 
   - Replace use of deprecated `bitSize` by `finiteBitSize`

--- a/murmur-hash.cabal
+++ b/murmur-hash.cabal
@@ -1,7 +1,6 @@
 Cabal-Version:   1.18
 Name:            murmur-hash
-Version:         0.1.0.10
-x-revision:      1
+Version:         0.1.0.11
 License:         BSD3
 License-File:    LICENSE
 Author:          Thomas Schilling


### PR DESCRIPTION
The current implementation for `ByteString` hashing requires many times more memory than the hashed data and causes a stack overflow if the `ByteString` is too large. This is PR fixes the issue by strict evaluation of the hash.

For lazy bytestrings this allows hashing in constant space, when treating them as streams. The following example runs with arbitrarily large inputs.

````haskell
main :: IO ()
main = do
  let gib = 1024 * 1024 * 1024
      contents = BL.take (50 * gib) $ BL.repeat 0
  print $ hash64 contents
````

I have verified that the hashes stay the same for the following strings as lazy (BL) and strict (BS) bytestrings.

````
(BL) "AAA"      Hash64 0xa35eab6e4dcc6458       Hash32 0x1f2c96d
(BL) "aaa"      Hash64 0x99a0cdf698b33a11       Hash32 0x5ec168b8
(BL) "FOOBAR"   Hash64 0x67de7c0fad236411       Hash32 0xbb60b0d3
(BS) "AAA"      Hash64 0x7fc0dac8b37d0287       Hash32 0xcf7ed713
(BS) "aaa"      Hash64 0x2b32d37fe2c25614       Hash32 0xbc1171ce
(BS) "FOOBAR"   Hash64 0x307a25cc9112e346       Hash32 0x543fa0dc
````

